### PR TITLE
ci: Update GitHub Actions to Latest Version

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -15,4 +15,4 @@ jobs:
             id-token: write
         steps:
             - id: deployment
-              uses: sphinx-notes/pages@3.5
+              uses: sphinx-notes/pages@3.6


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[sphinx-notes/pages](https://github.com/sphinx-notes/pages)** published a new release **[3.6](https://github.com/sphinx-notes/pages/releases/tag/3.6)** on 2026-04-15T13:31:57Z
